### PR TITLE
FIX missing backslash

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Usage
 =====
 ### Using a volume mapping
     docker run --rm \
-            -v /localpath/myProject:/neoload-project
+            -v /localpath/myProject:/neoload-project \
             -e NEOLOADWEB_API_URL={nlweb-onpremise-apiurl:port} \
             -e NEOLOADWEB_FILES_API_URL= {nlweb-onpremise-file-apiurl:port}\
             -e NEOLOADWEB_TOKEN={nlweb-token} \
@@ -29,7 +29,7 @@ Usage
             
 ### Using project URL
     docker run --rm \
-            -e NEOLOAD_PROJECT_URL={url-to-project-zip}
+            -e NEOLOAD_PROJECT_URL={url-to-project-zip} \
             -e NEOLOADWEB_API_URL={nlweb-onpremise-apiurl:port} \
             -e NEOLOADWEB_FILES_API_URL= {nlweb-onpremise-file-apiurl:port}\
             -e NEOLOADWEB_TOKEN={nlweb-token} \


### PR DESCRIPTION
It was missing a backslash on the second line of the docker run command.
If you copy/paste this command it will fail.